### PR TITLE
Fix bug with clear button not being disabled in facet.js

### DIFF
--- a/frontend/facet.js
+++ b/frontend/facet.js
@@ -214,6 +214,7 @@ function setupFacet(container, globalQuery, name, field, isConjunctive) {
 		}
 	};
 	clearElt.click(function () {
+		setClearEnabled(false);
 		clearConstraints();
 		globalQuery.update();
 	});


### PR DESCRIPTION
Previously, if you clicked it (after having selected something), the button
wouldn't get disabled.
