### PR TITLE
Take constraints into account when checking top X of facet.

### DIFF
--- a/frontend/compare.js
+++ b/frontend/compare.js
@@ -120,7 +120,7 @@ function setup(container, globalQuery, facets) {
 
 		}
 
-		currentFacet.constraintsQuery.onResult({
+		globalQuery.onResult({
 			counts: {
 				type: 'countbyfieldvalue',
 				field: currentFacet.field
@@ -130,6 +130,8 @@ function setup(container, globalQuery, facets) {
 			//		 It might be a good idea to check if it was already
 			//		 executed so we don't reload too many times.
 			var topNames = [];
+			current_domain = null;
+			hidden_names = [];
 
 			if (topCount < 0) {
 				topCount = result.counts.counts.length;
@@ -168,7 +170,7 @@ function setup(container, globalQuery, facets) {
 				});
 			});
 		});
-		currentFacet.constraintsQuery.update();
+		globalQuery.update();
 	});
 
 	/********************* END CALLBACKS ****************************/


### PR DESCRIPTION
The switch to globalQuery (from the per-facet query object) also means that the
plot is updated when a change happens in the facets, and it takes constraints
into account.

Fixes #161 