### PR TITLE
Fix symlink to libcblas.so on Ubuntu

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -11,7 +11,11 @@ build:
 	find $(SRC) -maxdepth 1 \( -name '*.py' -o -executable \) \( -not -type d \) -exec cp {} $(OUT) \;
 	find $(CONFIG) -maxdepth 1 -name '*.py' -exec cp {} $(OUT) \;
 	cp -r $(SRC)/bhtsne $(OUT)/
-	ln -s /usr/lib64/atlas/libcblas.so $(OUT)/bhtsne/libcblas.so
+	if grep --quiet "Ubuntu" /etc/lsb-release; then \
+		ln -s /usr/lib/libcblas.so $(OUT)/bhtsne/libcblas.so; \
+	else \
+		ln -s /usr/lib64/atlas/libcblas.so $(OUT)/bhtsne/libcblas.so; \
+	fi
 	cd $(OUT)/bhtsne
 	g++ $(OUT)/bhtsne/quadtree.cpp $(OUT)/bhtsne/tsne.cpp -o $(OUT)/bhtsne/bh_tsne -O3 -L$(OUT)/bhtsne -lcblas
 	mkdir $(OUT)/Temp


### PR DESCRIPTION
On Ubuntu, libcblas.so is in /usr/lib/, not in /usr/lib64/atlas/. This commit
checks if the operating system is Ubuntu and creates the appropriate symlink.

If the OS isn't Ubuntu, it works as before.