### PR TITLE
Check if /etc/lsb-release exists before grepping it

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -11,7 +11,7 @@ build:
 	find $(SRC) -maxdepth 1 \( -name '*.py' -o -executable \) \( -not -type d \) -exec cp {} $(OUT) \;
 	find $(CONFIG) -maxdepth 1 -name '*.py' -exec cp {} $(OUT) \;
 	cp -r $(SRC)/bhtsne $(OUT)/
-	if grep --quiet "Ubuntu" /etc/lsb-release; then \
+	if [ -e /etc/lsb-release ] && grep --quiet "Ubuntu" /etc/lsb-release; then \
 		ln -s /usr/lib/libcblas.so $(OUT)/bhtsne/libcblas.so; \
 	else \
 		ln -s /usr/lib64/atlas/libcblas.so $(OUT)/bhtsne/libcblas.so; \


### PR DESCRIPTION
This sort of addresses part of #176. This is more of a cosmetic fix, though, since the fact that `grep` says `No such file or directory` doesn't make the build fail in any way; the `if` statement still works as intended. It's just that `grep` ignores the `--quiet` flag in that situation.