### PR TITLE
Use the -p flag for mkdir so it doesn't fail

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -18,6 +18,6 @@ build:
 	fi
 	cd $(OUT)/bhtsne
 	g++ $(OUT)/bhtsne/quadtree.cpp $(OUT)/bhtsne/tsne.cpp -o $(OUT)/bhtsne/bh_tsne -O3 -L$(OUT)/bhtsne -lcblas
-	mkdir $(OUT)/Temp
+	mkdir -p $(OUT)/Temp
 clean:
 	rm -rf $(OUT)


### PR DESCRIPTION
Fixes an issue mentioned in #176 where re-building the backend fails because `Temp` already exists.

@theq629 does this work as expected?