### PR TITLE
Use /tmp instead of Temp/ in TSNE code

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -18,6 +18,5 @@ build:
 	fi
 	cd $(OUT)/bhtsne
 	g++ $(OUT)/bhtsne/quadtree.cpp $(OUT)/bhtsne/tsne.cpp -o $(OUT)/bhtsne/bh_tsne -O3 -L$(OUT)/bhtsne -lcblas
-	mkdir -p $(OUT)/Temp
 clean:
 	rm -rf $(OUT)

--- a/backend/bhtsne/bhtsne.py
+++ b/backend/bhtsne/bhtsne.py
@@ -59,7 +59,7 @@ DEFAULT_THETA = 0.5
 
 class TmpDir:
     def __enter__(self):
-        self._tmp_dir_path = mkdtemp(dir='/tmp')
+        self._tmp_dir_path = mkdtemp()
         return self._tmp_dir_path
 
     def __exit__(self, type, value, traceback):

--- a/backend/bhtsne/bhtsne.py
+++ b/backend/bhtsne/bhtsne.py
@@ -59,7 +59,7 @@ DEFAULT_THETA = 0.5
 
 class TmpDir:
     def __enter__(self):
-        self._tmp_dir_path = mkdtemp(dir='Temp/')
+        self._tmp_dir_path = mkdtemp(dir='/tmp')
         return self._tmp_dir_path
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
The Temp/ folder was created in the Makefile, and was a relative path
(restricting what the pwd could be when executing the program). This caused a
few issues.

/tmp is a standard place for putting these kinds files and we're usually
guaranteed that it will have the correct permissions for writing to it.

Fixes #179