### PR TITLE
Optionally load flask config from an env variable.

### DIFF
--- a/web/app/__init__.py
+++ b/web/app/__init__.py
@@ -8,6 +8,14 @@ from flask.ext.migrate import Migrate, MigrateCommand
 app = Flask(__name__)
 app.config.from_object('config')
 
+try:
+    app.config.from_envvar('LENSING_SETTINGS')
+except RuntimeError:
+    # This happens when the environment variable is not set.
+    # We can safely ignore this because we usually won't use this (unless we
+    # don't want to use local_config.py in a container).
+    pass
+
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 


### PR DESCRIPTION
This isn't particularly well documented right now (although it's a common pattern) because it shouldn't be used yet; `local_config.py` works best for our current deployment. This is going to be useful for the Docker containers and will be documented when that's merged.