### PR TITLE
Fix issue with AUFS chmod not sticking

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,8 +9,6 @@ RUN apt-get update && \
 
 ADD . /opt/lensing
 RUN chown -R www-data:www-data /opt/lensing
-RUN find /opt/lensing -type f -exec chmod 664 "{}" \;
-RUN find /opt/lensing -type d -exec chmod 775 "{}" \;
 
 RUN cp /opt/lensing/app.wsgi /var/www/lensing.wsgi
 RUN chown -R www-data:www-data /var/www
@@ -23,6 +21,8 @@ ADD deploy-config/ubuntu-virtualhost.conf /etc/apache2/sites-available/001-lensi
 RUN a2enmod wsgi
 RUN a2ensite 001-lensing
 
-# THIS CHMOD HAS TO BE HERE OR ELSE PYTHON CODE WON'T BE ABLE TO OPEN THE FILES
-# EVEN THOUGH THE PERMISSIONS ARE 664 ON THESE FILES
-CMD chmod 664 /opt/lensing/app/templates/* && apache2ctl -D FOREGROUND
+# - Reason for `rm`: If the container isn't stopped gracefully, and Apache
+#   didn't delete its lock files, it won't start up again (it'll say httpd is
+#   already running).
+CMD rm -rf /var/run/apache2/* /var/lock/apache2/* \
+    && apache2ctl -D FOREGROUND

--- a/website.md
+++ b/website.md
@@ -40,11 +40,14 @@ and URLs as needed.
 
 ## Set up docker on Ubuntu or CentOS 6/7
 
-Set up docker version 1.7.1 or greater on Ubuntu on CentOS 6 or CentOS 7. Installing on Ubuntu in easy. To install on CentOS follow the instructions in the following page:
+Set up docker version 1.7.1 or greater on Ubuntu on CentOS 6 or CentOS 7.
+Installing on Ubuntu in easy. To install on CentOS follow the instructions in
+the following page:
 
     http://blog.docker.com/2015/07/new-apt-and-yum-repos/
 
-After you have installed using `sudo yum install docker-engine` then install `docker-compose`:
+After you have installed using `sudo yum install docker-engine` then install
+`docker-compose`:
 
     sudo /usr/local/bin/pip-2.7 install docker-compose
 
@@ -85,7 +88,10 @@ in `web/README.md`. Place the `local_config.py` file in the same directory as
 `config.py` before you run `docker-compose build`, and it'll be added to the
 image.
 
-The defaults are set up to reflect the current directory structure and open ports on `natlang-web.cs.sfu.ca`
+The defaults are set up to reflect the current directory structure and open
+ports on `natlang-web.cs.sfu.ca`
+
+Make sure you have permissions 664 on files and 755 on directories in `web/`
 
 Then run the following commands:
 
@@ -94,9 +100,11 @@ Then run the following commands:
 
 ## Updating the site.
 
-To update the site, pull the new version from github and rebuild the docker images (using the same commands above).
+To update the site, pull the new version from github and rebuild the docker
+images (using the same commands above).
 
-When updating to a new docker image, you should check if the previous image was terminated gracefully:
+When updating to a new docker image, you should check if the previous image was
+terminated gracefully:
 
     sudo docker ps
     sudo docker kill CONTAINER-ID


### PR DESCRIPTION
Turns out, if you don't chmod anywhere in the Dockerfile, this works fine. It relies on having the correct permissions on the files on the host machine, though.

The core issue seems to be with AUFS and how different layers handle permissions (you can't have broader permissions on higher layers), but the permissions weren't broader or narrower; they were identical.

Either way, this appears to work now. I've mentioned the permission requirements in `website.md` before running `docker-compose build`.